### PR TITLE
Suppression de warning php

### DIFF
--- a/core/class/domogeek.class.php
+++ b/core/class/domogeek.class.php
@@ -26,7 +26,7 @@ class domogeek extends eqLogic {
     /*     * ***********************Methode static*************************** */
     
 
-    public static function pull($_options) {
+    public static function pull() {
         foreach (eqLogic::byType('domogeek') as $domogeek) {
 			$domogeek->getInformations();
 			


### PR DESCRIPTION
Bonjour,
J'ai supprimé un paramètre inutile de la fonction pull() afin d'eliminer les messages de Warning de mon serveur PHP.

Cdlt