### PR TITLE
Ajout de la traduction automne au retour de l'api season

### DIFF
--- a/core/class/domogeek.class.php
+++ b/core/class/domogeek.class.php
@@ -518,11 +518,11 @@ class domogeek extends eqLogic {
 						$cmd->event("printemps");
 					}elseif($season['season']=="summer"){
 						$cmd->event("été");
-					}elseif($season['season']=="fall"){
+					}elseif($season['season']=="fall" || $season['season']=="autumn"){
 						$cmd->event("automne");
 					}else{
 						$cmd->event($season['season']);
-					}					
+					}
 				}elseif($cmd->getConfiguration('data')=="ip_publique"){
 					$cmd->event($ip_publique['myip']);
 				}elseif($cmd->getConfiguration('data')=="feastedsaint"){
@@ -672,7 +672,7 @@ class domogeekCmd extends cmd {
 					return "printemps";
 				}elseif($season['season']=="summer"){
 					return "été";
-				}elseif($season['season']=="fall"){
+				}elseif($season['season']=="fall" || $season['season']=="autumn"){
 					return "automne";
 				}else{
 					return $season['season'];


### PR DESCRIPTION
L'api Season ne retourne plus la valeur Fall pour l'automne mais la valeur autumn.
 - Ajout d'un test supplémentaire sur la valeur de retour